### PR TITLE
Update Ubuntu Box URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ output "IPAddr" {
 
 - [ubuntu-15.04](https://github.com/ccll/terraform-provider-virtualbox-images/releases/tag/ubuntu-15.04)
 
-- [Ubuntu Vagrant box](https://atlas.hashicorp.com/ubuntu/boxes/trusty64/versions/14.04/providers/virtualbox.box])
+- [Ubuntu Vagrant box](https://vagrantcloud.com/ubuntu/boxes/trusty64/versions/20180206.0.0/providers/virtualbox.box])
 
 # TODO
 


### PR DESCRIPTION
Closes #15 

Update Ubuntu Box URL to point to vagrantcloud