### PR TITLE
Update examples.tf with correct location

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ output "IPAddr" {
 
 - [ubuntu-15.04](https://github.com/ccll/terraform-provider-virtualbox-images/releases/tag/ubuntu-15.04)
 
-- [Ubuntu Vagrant box](https://vagrantcloud.com/ubuntu/boxes/trusty64/versions/20180206.0.0/providers/virtualbox.box])
+- [Ubuntu Vagrant box](https://vagrantcloud.com/ubuntu/boxes/trusty64/versions/20180206.0.0/providers/virtualbox.box)
 
 # TODO
 

--- a/examples/example.tf
+++ b/examples/example.tf
@@ -2,7 +2,7 @@
 resource "virtualbox_vm" "node" {
     count = 2
     name = "${format("node-%02d", count.index+1)}"
-    url = "https://atlas.hashicorp.com/ubuntu/boxes/trusty64/versions/14.04/providers/virtualbox.box"
+    url = "https://vagrantcloud.com/ubuntu/boxes/trusty64/versions/20180206.0.0/providers/virtualbox.box"
     image = "./virtualbox-ubuntu.box"
     cpus = 2
     memory = "512 mib",


### PR DESCRIPTION
Fix typo in README.md to fix Ubuntu box location on vagrantcloud
Update example.tf to point to vagrantcloud instead of atlas