### PR TITLE
Use latest version of Go in Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: false
 language: go
 go:
-  - 1.9.1
+  - 1.11.4
 os:
   - linux
   - osx


### PR DESCRIPTION
Update to version 1.11.4 of Go. I think for safety its better to keep
the version locked to a specific one. This just means the version has to
be periodically updated.

This is also a requirement to use Go modules in the future (`go.mod` added in #36)