### PR TITLE
Fixed typo in example

### DIFF
--- a/examples/example.tf
+++ b/examples/example.tf
@@ -4,7 +4,7 @@ resource "virtualbox_vm" "node" {
   image     = "https://app.vagrantup.com/ubuntu/boxes/bionic64/versions/20180903.0.0/providers/virtualbox.box"
   cpus      = 2
   memory    = "512 mib"
-  user_data = file("${module.path}/user_data")
+  user_data = file("${path.module}/user_data")
 
   network_adapter {
     type           = "hostonly"


### PR DESCRIPTION
Fixed a variable being the wrong way round and this stopped the example's from working.