### PR TITLE
Use official golangci-lint GitHub action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Lint with golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: latest
+        version: v1.40.1
     
   build:
     name: build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,9 +13,10 @@ jobs:
       uses: actions/checkout@v1
       with:
         fetch-depth: 1
-    - uses: actions-contrib/golangci-lint@v1
+    - name: Lint with golangci-lint
+    - uses: golangci/golangci-lint-action@v2
       with:
-        args: run
+        version: latest
     
   build:
     name: build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       with:
         fetch-depth: 1
     - name: Lint with golangci-lint
-    - uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v2
       with:
         version: latest
     


### PR DESCRIPTION
This is the official Github Action from the golangci-lint team. It looks like the previous linter was removed and CI started to fail. The CI after the change fails due to unused function, but this is not related to the current change, so I think we should merge the change, and only then fix the linting problem.