### PR TITLE
Update go-virtualbox with no synthcpu changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,5 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/smartystreets/assertions v1.1.1 // indirect
 	github.com/smartystreets/goconvey v1.6.4
-	github.com/terra-farm/go-virtualbox v0.0.4
+	github.com/terra-farm/go-virtualbox v0.0.5-0.20210628144304-5f2cd9661101
 )

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/terra-farm/go-virtualbox v0.0.4 h1:UAEVNAYLA3g80Z//fMZFVSWHEPqRWkWP2gmFh2p/guQ=
 github.com/terra-farm/go-virtualbox v0.0.4/go.mod h1:5n2X+HKR2eAzHfuGFnrZlCrgiYrseNHIcNTSpA/ViyU=
+github.com/terra-farm/go-virtualbox v0.0.5-0.20210628144304-5f2cd9661101 h1:l8o5u/MKregDW9aBFlpmcUak+szmy83qBNDh3BEVWiw=
+github.com/terra-farm/go-virtualbox v0.0.5-0.20210628144304-5f2cd9661101/go.mod h1:AzCBcgfONAK4nUCMhG09XLc3oasGNLqg10QbVP68Yxo=
 github.com/ulikunitz/xz v0.5.5 h1:pFrO0lVpTBXLpYw+pnLj6TbvHuyjXMfjGeCwSqCVwok=
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
The flag is deprecated, and is causing problems as show in #105.