### PR TITLE
Use virtualbox.Run

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.1
 	github.com/pkg/errors v0.9.1
 	github.com/smartystreets/goconvey v1.6.4
-	github.com/terra-farm/go-virtualbox v0.0.5-0.20210628144304-5f2cd9661101
+	github.com/terra-farm/go-virtualbox v0.0.5-0.20210923155707-1e17d843762c
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -309,8 +309,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/terra-farm/go-virtualbox v0.0.5-0.20210628144304-5f2cd9661101 h1:l8o5u/MKregDW9aBFlpmcUak+szmy83qBNDh3BEVWiw=
-github.com/terra-farm/go-virtualbox v0.0.5-0.20210628144304-5f2cd9661101/go.mod h1:AzCBcgfONAK4nUCMhG09XLc3oasGNLqg10QbVP68Yxo=
+github.com/terra-farm/go-virtualbox v0.0.5-0.20210923155707-1e17d843762c h1:GUD6EcJwuE6ZOVSLa+Fh4/BMcB8NeC7zuJLRXHozviM=
+github.com/terra-farm/go-virtualbox v0.0.5-0.20210923155707-1e17d843762c/go.mod h1:AzCBcgfONAK4nUCMhG09XLc3oasGNLqg10QbVP68Yxo=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/virtualbox/resource_vm.go
+++ b/virtualbox/resource_vm.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -27,7 +26,6 @@ import (
 )
 
 var (
-	vbm              string // Path to VBoxManage utility.
 	defaultBootOrder = []string{"disk", "none", "none", "none"}
 )
 
@@ -244,12 +242,8 @@ func resourceVMCreate(ctx context.Context, d *schema.ResourceData, meta interfac
 		filename := filepath.Base(src)
 
 		target := filepath.Join(vm.BaseFolder, filename)
-		vbm = "VBoxManage"
-		if p := os.Getenv("VBOX_INSTALL_PATH"); p != "" && runtime.GOOS == "windows" {
-			vbm = filepath.Join(p, "VBoxManage.exe")
-		}
-		setUUIDCmd := exec.Command(vbm, "internalcommands", "sethduuid", src)
-		if err := setUUIDCmd.Run(); err != nil {
+
+		if _, _, err := vbox.Run(ctx, "internalcommands", "sethduuid", src); err != nil {
 			return diag.Errorf("unable to set UUID: %v", err)
 		}
 


### PR DESCRIPTION
When creating disk we try to manually find the VBoxManage binary, but
the go-virtualbox package already provides this functionality, and it
has better ability to find the binary.