### PR TITLE
added configuration for the delay and mintimeout for slow hardware

### DIFF
--- a/virtualbox/provider.go
+++ b/virtualbox/provider.go
@@ -14,6 +14,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// Provider configuration structure
+type Config struct {
+	Delay   int
+	MinTimeout int
+}
+
 func init() {
 	// Terraform is already adding the timestamp for us
 	log.SetFlags(log.Lshortfile)
@@ -23,8 +29,41 @@ func init() {
 // Provider returns a resource provider for virtualbox.
 func Provider() *schema.Provider {
 	return &schema.Provider{
+		// Provider configuration
+		Schema: map[string]*schema.Schema{
+			"delay": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"mintimeout": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+		},
+
 		ResourcesMap: map[string]*schema.Resource{
 			"virtualbox_vm": resourceVM(),
 		},
+
+		ConfigureFunc: providerConfigure,
 	}
+}
+
+func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	config := &Config{
+		Delay:   d.Get("delay").(int),
+		MinTimeout: d.Get("mintimeout").(int),
+	}
+
+	if config.Delay == 0 {
+		log.Printf("[INFO] No Delay was configured, using 60 seconds by default.")
+		config.Delay = 60
+	}
+
+	if config.MinTimeout == 0 {
+		log.Printf("[INFO] No MinTimeout was configured, using 5 seconds by default.")
+		config.MinTimeout = 5
+	}
+
+	return config, nil
 }

--- a/virtualbox/resource_vm.go
+++ b/virtualbox/resource_vm.go
@@ -512,6 +512,9 @@ func resourceVMDelete(d *schema.ResourceData, meta interface{}) error {
 
 // Wait until VM is ready, and 'ready' means the first non NAT NIC get a ipv4_address assigned
 func waitUntilVMIsReady(ctx context.Context, d *schema.ResourceData, vm *vbox.Machine, meta interface{}) error {
+	
+	config := meta.(*Config)
+
 	for i, nic := range vm.NICs {
 		if nic.Network == vbox.NICNetNAT {
 			continue
@@ -525,8 +528,8 @@ func waitUntilVMIsReady(ctx context.Context, d *schema.ResourceData, vm *vbox.Ma
 			[]string{"no"},
 			key,
 			meta,
-			30*time.Second,
-			1*time.Second,
+			time.Duration(config.Delay)*time.Second, // used to be hardcoded as 30
+			time.Duration(config.MinTimeout)*time.Second, // used to be hardcoded as 1
 		); err != nil {
 			return errors.Wrapf(err, "waiting for VM (%s) to become ready", d.Get("name"))
 		}


### PR DESCRIPTION
Added an option to control the configuration of the provider:
provider virtualbox {
    delay = 60   // default hardcoded value was 30
    mintimeout = 5  // default hardcoded value was 1
}
This will allow waiting for the VMs to become ready even on slow hardware and will give control over this to the end-user.