### PR TITLE
Deprecated and remove user_data

### DIFF
--- a/examples/example.tf
+++ b/examples/example.tf
@@ -4,7 +4,6 @@ resource "virtualbox_vm" "node" {
   image     = "https://app.vagrantup.com/ubuntu/boxes/bionic64/versions/20180903.0.0/providers/virtualbox.box"
   cpus      = 2
   memory    = "512 mib"
-  user_data = file("${path.module}/user_data")
 
   network_adapter {
     type           = "hostonly"

--- a/examples/user_data
+++ b/examples/user_data
@@ -1,4 +1,0 @@
-{
-    "role": "worker",
-    "foo": "bar"
-}

--- a/virtualbox/resource_vm.go
+++ b/virtualbox/resource_vm.go
@@ -86,9 +86,10 @@ func resourceVM() *schema.Resource {
 			},
 
 			"user_data": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "",
+				Deprecated: "user_data is not working and is temporarily deprecated while we figure out how to make it work",
+				Type:       schema.TypeString,
+				Optional:   true,
+				Default:    "",
 			},
 
 			"checksum": {
@@ -420,17 +421,6 @@ func resourceVMRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		return diag.Errorf("can't set memory: %v", err)
 	}
 
-	userData, err := vm.GetExtraData("user_data")
-	if err != nil {
-		return diag.Errorf("can't get user data: %v", err)
-	}
-	if userData != nil && *userData != "" {
-		err = d.Set("user_data", *userData)
-		if err != nil {
-			return diag.Errorf("can't set user_data: %v", err)
-		}
-	}
-
 	if err = netVboxToTf(vm, d); err != nil {
 		return diag.Errorf("can't convert vbox network to terraform data: %v", err)
 	}
@@ -556,10 +546,6 @@ func tfToVbox(ctx context.Context, d *schema.ResourceData, vm *vbox.Machine) err
 		vbox.HWVIRTEX | vbox.NESTEDPAGING | vbox.LARGEPAGES | vbox.LONGMODE |
 		vbox.VTXVPID | vbox.VTXUX
 	vm.NICs, err = netTfToVbox(ctx, d)
-	userData := d.Get("user_data").(string)
-	if userData != "" {
-		err = vm.SetExtraData("user_data", userData)
-	}
 	vm.BootOrder = defaultBootOrder
 	for i, bootDev := range d.Get("boot_order").([]any) {
 		vm.BootOrder[i] = bootDev.(string)

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     virtualbox = {
       source = "terra-farm/virtualbox"
-      version = "0.2.1"
+      version = "<latest-tag>"
     }
   }
 }
@@ -34,7 +34,6 @@ resource "virtualbox_vm" "node" {
   image     = "https://app.vagrantup.com/ubuntu/boxes/bionic64/versions/20180903.0.0/providers/virtualbox.box"
   cpus      = 2
   memory    = "512 mib"
-  user_data = file("${path.module}/user_data")
 
   network_adapter {
     type           = "hostonly"

--- a/website/docs/r/vm.html.markdown
+++ b/website/docs/r/vm.html.markdown
@@ -18,7 +18,6 @@ resource "virtualbox_vm" "node" {
   image     = "https://app.vagrantup.com/ubuntu/boxes/bionic64/versions/20180903.0.0/providers/virtualbox.box"
   cpus      = 2
   memory    = "512 mib"
-  user_data = file("${path.module}/user_data")
 
   network_adapter {
     type           = "hostonly"
@@ -40,7 +39,6 @@ The following arguments are supported:
 - `cpus`, int, optional, default=2: The number of CPUs.
 - `memory`, string, optional, default="512mib": The size of memory, allow human
   friendly units like 'MB', 'MiB'.
-- `user_data`, string, optional, default="": User defined data.
 - `status`, string, optional, default="running": The status of the VM. This
   value will be updated at runtime to reflect the real status of the VM,
   and you can also specify it explicitly in config to manually control the


### PR DESCRIPTION
As per #150, the user_data is not working, so the field is marked as
deprecated until its fixed.

All references from the examples and docs have been removed to avoid
confusion.