### PR TITLE
Enables enformement support for EFI bootable images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@ GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 
 default: build
 
-build: fmtcheck
+build:
 	go install
 
-test: fmtcheck
+test:
 	go test -i -race -coverprofile=coverage.txt -covermode=atomic || exit 1
 
-testacc: fmtcheck
+testacc:
 	TF_ACC=1 go test -v $(TESTARGS) -timeout 120m
 
 vet:
@@ -22,9 +22,6 @@ vet:
 
 fmt:
 	gofmt -w $(GOFMT_FILES)
-
-fmtcheck:
-	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
 errcheck:
 	@sh -c "'$(CURDIR)/scripts/errcheck.sh'"

--- a/internal/provider/resource_vm.go
+++ b/internal/provider/resource_vm.go
@@ -156,6 +156,12 @@ func resourceVM() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				MaxItems:    4,
 			},
+
+			"firmware": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Flags the EFI custom firmware flag in system settings",
+			},
 		},
 	}
 }
@@ -451,6 +457,11 @@ func resourceVMRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		return diag.Errorf("can't set boot_order: %v", err)
 	}
 
+	err = d.Set("firmware", vm.Firmware)
+	if err != nil {
+		return diag.Errorf("can't set firmware: %v", err)
+	}
+
 	return nil
 }
 
@@ -541,6 +552,7 @@ func tfToVbox(ctx context.Context, d *schema.ResourceData, vm *vbox.Machine) err
 	}
 	vm.Memory = uint(bytes / humanize.MiByte) // VirtualBox expect memory to be in MiB units
 
+	vm.Firmware = d.Get("firmware").(string)
 	vm.VRAM = 20 // Always 10MiB for vram
 	vm.Flag = vbox.ACPI | vbox.IOAPIC | vbox.RTCUSEUTC | vbox.PAE |
 		vbox.HWVIRTEX | vbox.NESTEDPAGING | vbox.LARGEPAGES | vbox.LONGMODE |


### PR DESCRIPTION
Currently the option is not managed

Enable flag with

```
resource "virtualbox_vm" "node" {
  count     = 1
  name      = format("node-%02d", count.index + 1)
  image     = yourova.ova"
  cpus      = 2
  memory    = "512 mib"
  ## **** see here ****
  firmware  = "efi"

  network_adapter {
    type           = "bridged"
    host_interface = "enp0s31f6"
  }
}
```

should give you this under "System"

![image](https://github.com/terra-farm/terraform-provider-virtualbox/assets/3090891/c63cdc13-48d7-4019-a69d-b146a8aba644)


